### PR TITLE
fix: revert remove mas-sso object

### DIFF
--- a/src/contexts/config/Config.ts
+++ b/src/contexts/config/Config.ts
@@ -39,23 +39,6 @@ export type Config = {
         basePath: string
     }
     /**
-     * masSSO provides configuration for our integration with MASSSO
-     */
-    masSso: {
-        /**
-         * authServerUrl is the URL of the SSO server
-         */
-        authServerUrl: string,
-        /**
-         * clientId is the OpenID Connect client ID the UI uses to talk to MASSSO
-         */
-        clientId: string,
-        /**
-         * realm is the realm the service uses on MASSSO
-         */
-        realm: string
-    }
-    /**
      * kafka provides configuration for our integration with the Kafka instance
      */
     kafka?: {


### PR DESCRIPTION
Reverts redhat-developer/app-services-ui-shared#128
Removing mas-sso object as we will not needed after mas-sso code cleaning.