### PR TITLE
feat: Adding SA UI Auth Context

### DIFF
--- a/src/contexts/auth/Auth.ts
+++ b/src/contexts/auth/Auth.ts
@@ -47,6 +47,12 @@ export type Auth = {
          * Get the token for accessing Smart Events
          */
         getToken: () => Promise<string> | undefined
+    },
+    sas_ui: {
+        /**
+         * Get the token for accessing Service Accounts UI
+         */
+        getToken: () => Promise<string> | undefined
     }
 }
 


### PR DESCRIPTION
This is in regards to the initiative for the CIAM team to migrating and creating a new federated module for the service accounts UI.

Adding authentication context for use within this new service accounts ui federated module.